### PR TITLE
Fixes to Imm6 handling and mixed-case opcode parsing

### DIFF
--- a/parse_opcodes
+++ b/parse_opcodes
@@ -652,6 +652,7 @@ def make_rust():
   for a in distinct_args:
     print("    // Format::{0}".format(make_camel_case_arg(a)))
     for n in insts_by_args[a]:
+      n = n.lower()
       print("    {}: u8,".format("_".join(n.split('.'))))
   print("}")
   print()
@@ -663,6 +664,7 @@ def make_rust():
   print("        Latency {")
   for a in distinct_args:
     for n in insts_by_args[a]:
+      n = n.lower()
       print("        {}: 1,".format("_".join(n.split('.'))))
   print("        }")
   print("    }")

--- a/parse_opcodes
+++ b/parse_opcodes
@@ -78,6 +78,11 @@ bits_jimm20 = [
   ("jimm20", 19, 19, 20), # jimm20[19]   -> imm[20]
 ]
 
+bits_imm6 = [
+  ("imm6", 4, 0, 1),      # imm6[4:0] -> imm[5:1]
+  ("imm6", 5, 5, 0),      # imm6[5] -> imm[0]
+]
+
 causes = [
   (0x00, 'misaligned fetch'),
   (0x01, 'fetch access'),
@@ -566,6 +571,10 @@ def make_rust():
     if "jimm20" in a:
       print("    pub fn jimm(&self) -> i32 {")
       print("        {}".format(make_rust_field_shuffle(bits_jimm20, 21)));
+      print("    }")
+    if "imm6" in a:
+      print("    pub fn imm(&self) -> i32 {")
+      print("        {}".format(make_rust_field_shuffle(bits_imm6, 6)));
       print("    }")
     print("}")
     print()


### PR DESCRIPTION
- Imm6: Imm6 on bits [25:20] is ordered as {imm6lo, imm6hi}={[24:20],[25]} in the xpulp extension
   - to better handle this in general imm6 is split into imm6hi and imm6lo
   - to better handle it in Rust parse_opcodes adds a field where necessary which contains the correctly ordered imm6
   - opcode files have been changed accordingly
- Mixed-case opcode names: if there are mixed-case opcode names then the parsing for Rust needs this in lower case at some points