### PR TITLE
Fix removal of `logic` from sverilog generation

### DIFF
--- a/parse_opcodes
+++ b/parse_opcodes
@@ -1253,7 +1253,7 @@ def make_chisel():
   print('}')
 
 def print_sverilog_insn(name):
-  s = "  localparam [31:0] %-18s = 32'b" % name.replace('.', '_').upper()
+  s = "  localparam logic [31:0] %-18s = 32'b" % name.replace('.', '_').upper()
   for i in range(31, -1, -1):
     if yank(mask[name], i, 1):
       s = '%s%d' % (s, yank(match[name], i, 1))


### PR DESCRIPTION
`logic` was removed between `localparam` and `[31:0]` in sverilog generation of parse_opcodes erroneously