### PR TITLE
Drop `frep.i` instruction for nested FREP

### DIFF
--- a/opcodes-frep_CUSTOM
+++ b/opcodes-frep_CUSTOM
@@ -15,5 +15,4 @@
 # INFO: overlaps with opcodes-xpulppostmod_CUSTOM
 
 frep.o          rs1 imm12 stagger_max stagger_mask 7=1 6..2=0x02 1..0=3
-frep.i          rs1 imm12 stagger_max stagger_mask 7=0 6..2=0x02 1..0=3
 irep            rd rs1 imm12 rm 6..2=0x0F 1..0=3


### PR DESCRIPTION
Drop `frep.i` instruction in favour of nested FREP feature, which cannot be easily implemented in a compatible manner.